### PR TITLE
Add erratum

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ We also provide a PDF file that has color images of the screenshots/diagrams use
 ## Errata
 * Page 581 (Section 5, heading): **The PostegreSQL System** _should be_ **The PostgreSQL System**
 * Page 82 (Dropping databases, first paragraph): **to drop a table** _should be_ **to drop a database**
+* Page 114 (Using the IN/NOT IN condition, last paragraph): **the values `pk=2` and `pk=4`** _should be_ **the single value `pk=11`**; **that have `pk=2` or `pk=4`** _should be_ **that have `category=11`**.
 
 ### Related products 
 * Mastering PostgreSQL 12 [[Packt]](https://www.packtpub.com/product/mastering-postgresql-12-third-edition/9781838988821) [[Amazon]](https://www.amazon.com/dp/1838988823)


### PR DESCRIPTION
Maybe you would want to rework this example, since the `IN` operator does not really make sense (an equal would be enough) as there is only one value in the list.