### PR TITLE
Add erratum

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,5 +173,5 @@ has been passionate about computer science since he was a 13-year-old, his first
 #### Errata
 * Page 82 (Dropping databases, first paragraph): **to drop a table** _should be_ **to drop a database**
 * Page 581 (Section 5, heading): **The PostegreSQL System** _should be_ **The PostgreSQL System**
-
+* Page 119 (Using LEFT JOINS, first information paragraph): **and all the records from the right table (table2).** _should be_ **and all the records from the right table (table2) that match the left table (table1)**
 


### PR DESCRIPTION
I used the same sentence as in the next section (Using RIGHT JOIN). Note that one section speaks about joins (plural) and the other about join (singular). Probably just a typo.